### PR TITLE
Remove hardcoded timeout

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -15,8 +15,7 @@ var Clearbit = module.exports = integration('Clearbit')
   .endpoint('https://segment.clearbit.com/v2/events')
   .channels(['client', 'mobile', 'server'])
   .ensure('settings.apiKey')
-  .mapper(mapper)
-  .timeout('3s');
+  .mapper(mapper);
 
 /**
  * Identify.
@@ -31,5 +30,4 @@ Clearbit.prototype.identify = function(payload, done){
     .auth(this.settings.apiKey, '')
     .send(payload)
     .end(this.handle(done));
-};;
-
+};


### PR DESCRIPTION
Linux's default TCP retransmission timeout is 3s, so if packets are lost
early in the connection then an otherwise successful connection will
time out. This allows this integration to use the default (currently
10s) to avoid that problem.